### PR TITLE
WAL-230647 Prevent double click

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,7 +15,7 @@ android {
         applicationId = "com.wallee.samples.apps.shop"
         minSdk = libs.versions.minSdk.get().toInt()
         targetSdk = libs.versions.targetSdk.get().toInt()
-        versionCode = 8
+        versionCode = 9
         versionName = "1.3.0"
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/com/wallee/samples/apps/shop/compose/cart/ShopCartScreen.kt
+++ b/app/src/main/java/com/wallee/samples/apps/shop/compose/cart/ShopCartScreen.kt
@@ -1,5 +1,6 @@
 package com.wallee.samples.apps.shop.compose.cart
 
+import android.util.Log
 import androidx.activity.compose.ReportDrawn
 import androidx.activity.compose.ReportDrawnWhen
 import androidx.compose.foundation.layout.*
@@ -29,6 +30,7 @@ import com.wallee.samples.apps.shop.data.portal.LineItems
 import com.wallee.samples.apps.shop.data.portal.Transaction
 import com.wallee.samples.apps.shop.viewmodels.*
 import com.wallee.walleepaymentsdk.enums.PaymentResultEnum
+import kotlinx.coroutines.launch
 import java.util.*
 
 @Composable
@@ -126,22 +128,39 @@ private fun Checkout(
 
     val (snackbarVisibleState, setSnackBarState) = remember { mutableStateOf(false) }
 
+    val scope = rememberCoroutineScope()
+
+    suspend fun debounce(waitMs: Long = 300L, block: () -> Unit) {
+        var lastClick = 0L
+        val now = System.currentTimeMillis()
+        if (now - lastClick >= waitMs) {
+            lastClick = now
+            block()
+        }
+    }
+
     Button(
         colors = ButtonDefaults.buttonColors(backgroundColor = MaterialTheme.colors.primary),
         shape = MaterialTheme.shapes.large,
         modifier = Modifier.fillMaxWidth(),
+        enabled = portalViewModel.isLoading.collectAsState().value.not(),
         onClick = {
-            if (configViewModel.isConfigSettingsEmpty()) {
-                setSnackBarState(true)
-            } else {
-                val transaction = createTransaction(itemList.sumOf { item -> item.item.price })
-                val settings = Settings(
-                    configViewModel.getUserId(),
-                    configViewModel.getSpaceId(),
-                    configViewModel.getAuthenticationKey()
-                )
-                portalViewModel.createToken(transaction, settings, launchSdk)
+            scope.launch {
+                debounce(1000) {
+                    if (configViewModel.isConfigSettingsEmpty()) {
+                        setSnackBarState(true)
+                    } else {
+                        val transaction = createTransaction(itemList.sumOf { item -> item.item.price })
+                        val settings = Settings(
+                            configViewModel.getUserId(),
+                            configViewModel.getSpaceId(),
+                            configViewModel.getAuthenticationKey()
+                        )
+                        portalViewModel.createToken(transaction, settings, launchSdk)
+                    }
+                }
             }
+
         }) {
         Text(
             color = MaterialTheme.colors.onPrimary,

--- a/app/src/main/java/com/wallee/samples/apps/shop/viewmodels/PortalViewModel.kt
+++ b/app/src/main/java/com/wallee/samples/apps/shop/viewmodels/PortalViewModel.kt
@@ -21,8 +21,14 @@ class PortalViewModel @Inject constructor(private val repository: PortalReposito
         _showResult.value = false
     }
 
+    private val _isLoading = MutableStateFlow(false)
+    val isLoading: StateFlow<Boolean>
+        get() = _isLoading
+
     fun createToken(transaction: String, settings: Settings, launchSdk: (String) -> Unit) {
         viewModelScope.launch {
+            _isLoading.value = true
+
             val transactionResult = repository.createTransaction(transaction, settings)
 
             if (transactionResult.isSuccessful) {
@@ -41,6 +47,7 @@ class PortalViewModel @Inject constructor(private val repository: PortalReposito
             } else {
                 _showResult.value = true
             }
+            _isLoading.value = false
         }
 
     }


### PR DESCRIPTION
When I perform a trx with Direct Debit (SEPA) bogus processor, after trx has been payed, payment methods are still shown. 

And, in order to see completed trx banner, I have to click on 'X' icon to close the payment methods, which leads to adding a cancelled trx entry to the portal trx